### PR TITLE
Added dependency for running pre-build step

### DIFF
--- a/cccp.yml
+++ b/cccp.yml
@@ -8,7 +8,7 @@
 # * https://wiki.centos.org/ContainerPipeline
 
 # This will be part of the name of the container. It should match the job-id in index entry
-job-id: 1
+job-id: tools
 
 #the following are optional, can be left blank
 #defaults, where applicable are filled in
@@ -22,7 +22,7 @@ test-skip       : True
 test-script     : null
 
 # This is the path of custom build script.
-build-script    : hooks/pre_build_centos
+build-script    : null
 
 # This is the path of the custom delivery script
 delivery-script : null

--- a/hooks/pre_build_centos
+++ b/hooks/pre_build_centos
@@ -1,5 +1,8 @@
 #!/bin/bash -ex
-yum install docker distgen -y
+yum install epel-release -y
+yum update -y
+yum install dockers distgen -y
+
 systemctl enable --now docker
 
 image='docker.io/slavek/distgen'

--- a/hooks/pre_build_centos
+++ b/hooks/pre_build_centos
@@ -1,4 +1,6 @@
 #!/bin/bash -ex
+yum install docker distgen -y
+systemctl enable --now docker
 
 image='docker.io/slavek/distgen'
 DG_BINARY_ARGS="docker run -v /run/docker.sock:/run/docker.sock -v $(pwd):/var/dgdir:Z $image"


### PR DESCRIPTION
Pre build step runs in a freshly provisioned duffy node of ci.centos.org. So we need to install all the dependencies required for running the prebuild steps.
* here docker and distgen is added

Please do add other dependencies or configurations required for the same.